### PR TITLE
Persist pricing in database

### DIFF
--- a/ClaudeNein/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/ClaudeNein/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -14,4 +14,11 @@
         <attribute name="requestId" attributeType="String" isOptional="YES"/>
         <attribute name="messageId" attributeType="String" isOptional="YES"/>
     </entity>
+    <entity name="ModelPriceEntity" representedClassName="ModelPriceEntity">
+        <attribute name="modelName" attributeType="String" isOptional="NO"/>
+        <attribute name="inputPrice" attributeType="Double" isOptional="NO"/>
+        <attribute name="outputPrice" attributeType="Double" isOptional="NO"/>
+        <attribute name="cacheCreationPrice" attributeType="Double" isOptional="YES"/>
+        <attribute name="cacheReadPrice" attributeType="Double" isOptional="YES"/>
+    </entity>
 </model>

--- a/PLAN.md
+++ b/PLAN.md
@@ -43,7 +43,8 @@ Build a macOS menu bar application that displays real-time Claude Code spending 
 - [x] Create `PricingManager` class:
   - [x] Fetch LiteLLM pricing data from API
   - [x] Implement offline fallback with bundled pricing data
-  - [x] Cache pricing data locally with expiration
+- [x] Cache pricing data locally with expiration
+- [x] Persist pricing data to Core Data with 4h refresh schedule
 - [x] Implement cost calculation logic:
   - [x] Calculate costs from token counts using model pricing
   - [x] Handle different token types (input, output, cache)


### PR DESCRIPTION
## Summary
- save model pricing in Core Data
- load cached pricing from the DB
- periodically refresh pricing every four hours
- document completed plan item

## Testing
- `xcodebuild -list -project ClaudeNein.xcodeproj` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_6882734167448332aa4ddf4a02664f73