### PR TITLE
Add unsigned build workflow

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,33 @@
+name: Build unsigned app
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      - name: Build app
+        run: |
+          xcodebuild \
+            -project ClaudeNein.xcodeproj \
+            -scheme ClaudeNein \
+            -configuration Release \
+            -derivedDataPath build
+      - name: Package app
+        run: |
+          mkdir -p dist
+          ditto -c -k --sequesterRsrc --keepParent build/Build/Products/Release/ClaudeNein.app dist/ClaudeNein-unsigned.zip
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClaudeNein-unsigned
+          path: dist/ClaudeNein-unsigned.zip

--- a/PLAN.md
+++ b/PLAN.md
@@ -168,7 +168,7 @@ Build a macOS menu bar application that displays real-time Claude Code spending 
   - [ ] Minimum macOS version support
   - [ ] Universal binary (Intel + Apple Silicon)
 - [ ] Create build scripts:
-  - [ ] Archive and export workflow
+  - [x] Archive and export workflow
   - [ ] Automated testing in CI
 - [ ] Prepare for distribution:
   - [ ] App store preparation (if applicable)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Claude Nein lives in your macOS menu bar, keeping you constantly updated on your
 3. Build and run the project to launch the menu bar app.
 4. To run the unit tests use `xcodebuild test -scheme ClaudeNein -destination 'platform=macOS'`.
 
+### Prebuilt Unsigned App
+
+1. Open the **Actions** tab on GitHub and select the latest **Build unsigned app** workflow run.
+2. Download the `ClaudeNein-unsigned.zip` artifact and unzip it.
+3. Move `ClaudeNein.app` to your `/Applications` folder.
+4. Because the app is unsigned, right-click the app and choose **Open** the first time you launch it to bypass Gatekeeper.
+
 ## Technical Details
 
 -   **Language**: Swift


### PR DESCRIPTION
## Summary
- publish unsigned app build as an artifact
- describe how to install an unsigned app from the workflow artifact
- mark the plan step for creating an archive workflow

## Testing
- `xcodebuild -scheme ClaudeNein -configuration Release -derivedDataPath build` *(fails: command not found)*
- `xcodebuild test -scheme ClaudeNein -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68829687cad0833295d68aa8fef9bdbc