### PR TITLE
Add pricing refresh UI

### DIFF
--- a/ClaudeNein/ClaudeNeinApp.swift
+++ b/ClaudeNein/ClaudeNeinApp.swift
@@ -174,12 +174,21 @@ class MenuBarManager: ObservableObject {
         let dataSourceItem = NSMenuItem(title: "Pricing: \(dataSource.description)", action: nil, keyEquivalent: "")
         dataSourceItem.isEnabled = false
         menu.addItem(dataSourceItem)
-        
+
+        let pricingTime = PricingManager.shared.getLastFetchDate()
+        let pricingTimeItem = NSMenuItem(title: "Pricing Updated: \(formatTime(pricingTime))", action: nil, keyEquivalent: "")
+        pricingTimeItem.isEnabled = false
+        menu.addItem(pricingTimeItem)
+
         menu.addItem(NSMenuItem.separator())
-        
+
         let refreshItem = NSMenuItem(title: "Refresh Data", action: #selector(refreshData), keyEquivalent: "r")
         refreshItem.target = self
         menu.addItem(refreshItem)
+
+        let refreshPricingItem = NSMenuItem(title: "Refresh Pricing", action: #selector(refreshPricing), keyEquivalent: "")
+        refreshPricingItem.target = self
+        menu.addItem(refreshPricingItem)
         
         let reloadDatabaseItem = NSMenuItem(title: "Reload Database", action: #selector(reloadDatabase), keyEquivalent: "")
         reloadDatabaseItem.target = self
@@ -208,6 +217,16 @@ class MenuBarManager: ObservableObject {
         Logger.app.info("🔄 Manual refresh requested")
         Task {
             await processAllJsonlFiles()
+        }
+    }
+
+    @objc private func refreshPricing() {
+        Logger.app.info("🔄 Manual pricing refresh requested")
+        Task {
+            await PricingManager.shared.refreshPricingNow()
+            await MainActor.run {
+                self.updateMenu()
+            }
         }
     }
     

--- a/PLAN.md
+++ b/PLAN.md
@@ -94,7 +94,9 @@ Build a macOS menu bar application that displays real-time Claude Code spending 
   - [x] This month's spend
   - [x] Separator and additional options
 - [x] Add interactive elements:
-  - [x] "Refresh" menu item for manual updates
+- [x] "Refresh" menu item for manual updates
+  - [x] "Refresh Pricing" menu item
+  - [x] Display pricing last fetched time in menu
   - [x] "Grant/Revoke Access" menu items for home directory permissions
   - [x] "Reload Database" menu item with confirmation dialog for clearing all cached data
   - [x] "Quit" menu item


### PR DESCRIPTION
## Summary
- track last pricing fetch time in PricingManager
- expose manual refresh method
- show pricing update time in the menu
- add "Refresh Pricing" menu action
- mark tasks complete in PLAN

## Testing
- `xcodebuild -scheme ClaudeNein -sdk macosx -configuration Debug -quiet build` *(fails: command not found)*
- `xcodebuild test -scheme ClaudeNein -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688299eb55f88332a4e3683176ab1e97