### PR TITLE
Add tag-based unsigned build workflow

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -1,0 +1,40 @@
+name: Build unsigned app
+
+permissions:
+  contents: write
+
+on:
+  push:
+    tags: [ "*" ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      - name: Set build version
+        run: echo "VERSION=${GITHUB_REF_NAME}" >> "$GITHUB_ENV"
+      - name: Build app
+        run: |
+          xcodebuild \
+            -project ClaudeNein.xcodeproj \
+            -scheme ClaudeNein \
+            -configuration Release \
+            -derivedDataPath build \
+            MARKETING_VERSION="$VERSION"
+      - name: Package app
+        run: |
+          mkdir -p dist
+          ditto -c -k --sequesterRsrc --keepParent build/Build/Products/Release/ClaudeNein.app "dist/ClaudeNein-${VERSION}-unsigned.zip"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ClaudeNein-${{ env.VERSION }}-unsigned
+          path: "dist/ClaudeNein-${{ env.VERSION }}-unsigned.zip"
+      - name: Create draft release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          files: "dist/ClaudeNein-${{ env.VERSION }}-unsigned.zip"

--- a/PLAN.md
+++ b/PLAN.md
@@ -168,7 +168,7 @@ Build a macOS menu bar application that displays real-time Claude Code spending 
   - [ ] Minimum macOS version support
   - [ ] Universal binary (Intel + Apple Silicon)
 - [ ] Create build scripts:
-  - [ ] Archive and export workflow
+  - [x] Archive and export workflow
   - [ ] Automated testing in CI
 - [ ] Prepare for distribution:
   - [ ] App store preparation (if applicable)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ Claude Nein lives in your macOS menu bar, keeping you constantly updated on your
 3. Build and run the project to launch the menu bar app.
 4. To run the unit tests use `xcodebuild test -scheme ClaudeNein -destination 'platform=macOS'`.
 
+### Prebuilt Unsigned App
+
+1. Visit the **Releases** page on GitHub and download the `ClaudeNein-<version>-unsigned.zip` asset for the tag you want.
+2. Unzip the archive and move `ClaudeNein.app` to your `/Applications` folder.
+3. Because the app is unsigned, right-click the app and choose **Open** the first time to bypass Gatekeeper.
+
 ## Technical Details
 
 -   **Language**: Swift


### PR DESCRIPTION
## Summary
- run CI workflow only when tags are pushed
- set the build's marketing version from the tag
- zip the unsigned app with the tag in the name
- publish a draft release and upload the artifact
- document how to install the unsigned app from Releases

## Testing
- `xcodebuild -scheme ClaudeNein -configuration Release -derivedDataPath build` *(fails: command not found)*
- `xcodebuild test -scheme ClaudeNein -destination 'platform=macOS'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68829687cad0833295d68aa8fef9bdbc