### PR TITLE
Add Swift Package manifest

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-testing.git",
+      "state" : {
+        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
+        "version" : "0.99.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "ClaudeNein",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "ClaudeNein", targets: ["ClaudeNein"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-testing.git", from: "0.9.0")
+    ],
+    targets: [
+        .target(
+            name: "ClaudeNein",
+            path: "ClaudeNein",
+            exclude: ["Info.plist", "ClaudeNein.entitlements"],
+            resources: [
+                .process("Assets.xcassets"),
+                .process("Model.xcdatamodeld")
+            ]
+        ),
+        .testTarget(
+            name: "ClaudeNeinTests",
+            dependencies: [
+                "ClaudeNein",
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "ClaudeNeinTests",
+            resources: [
+                .copy("TestData")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- add `Package.swift` describing the project as a Swift package
- include resolved package dependencies

## Testing
- `xcodebuild test -scheme ClaudeNein -destination 'platform=macOS'` *(fails: command not found)*
- `swift test --disable-sandbox` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_688306cc1a488332ab21fe91108c68f8