### PR TITLE
Configure GitHub Actions for universal binary builds

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -23,6 +23,7 @@ jobs:
             -scheme ClaudeNein \
             -configuration Release \
             -derivedDataPath build \
+            -arch x86_64 -arch arm64 \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,6 @@ jobs:
         xcodebuild test \
           -project ClaudeNein.xcodeproj \
           -scheme ClaudeNein \
-          -destination 'platform=macOS,arch=x86_64' \
+          -destination 'platform=macOS' \
           -configuration Debug \
           -enableCodeCoverage YES

--- a/PLAN.md
+++ b/PLAN.md
@@ -173,7 +173,7 @@ Build a macOS menu bar application that displays real-time Claude Code spending 
 - [ ] Configure build settings:
   - [ ] Code signing and notarization
   - [ ] Minimum macOS version support
-  - [ ] Universal binary (Intel + Apple Silicon)
+  - [x] Universal binary (Intel + Apple Silicon)
 - [x] Create build scripts:
   - [x] Archive and export workflow
   - [x] Automated testing workflow (xcodebuild commands documented)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Claude Nein lives in your macOS menu bar, keeping you constantly updated on your
 
 ### Prebuilt Unsigned App
 The app is not yet published to the App Store, so the process of installing it is a bit convoluted:
-1. Visit the **Releases** page on GitHub and download the `ClaudeNein-<version>-unsigned.zip` asset for the tag you want.
+1. Visit the [Releases](https://github.com/forketyfork/claude-nein/releases) page and download the `ClaudeNein-<version>-unsigned.zip` asset from the latest release.
 2. Unzip the archive and move `ClaudeNein.app` to your `/Applications` folder.
 3. Reset the quarantine flag on the app: `xattr -d com.apple.quarantine /Applications/ClaudeNein.app`
 4. Because the app is unsigned, right-click the app and choose **Open** the first time to bypass Gatekeeper.


### PR DESCRIPTION
- Add -arch x86_64 -arch arm64 flags to build both Intel and ARM versions
- Update artifact names to maintain unsigned suffix
- Remove architecture-specific destination in test workflow
- Mark universal binary task as completed in PLAN.md