### PR TITLE
Fix GitHub Actions to build universal macOS binary

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -23,7 +23,8 @@ jobs:
             -scheme ClaudeNein \
             -configuration Release \
             -derivedDataPath build \
-            -arch x86_64 -arch arm64 \
+            ARCHS="x86_64 arm64" \
+            ONLY_ACTIVE_ARCH=NO \
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \


### PR DESCRIPTION
- Replace -arch flags with ARCHS build setting to ensure proper universal binary creation
- Add ONLY_ACTIVE_ARCH=NO to build all specified architectures
- This fixes the issue where Intel Macs couldn't run the downloaded artifacts