### PR TITLE
Improve date rollover detection with periodic check approach

### DIFF
--- a/ClaudeNein/ClaudeNeinApp.swift
+++ b/ClaudeNein/ClaudeNeinApp.swift
@@ -39,9 +39,9 @@ class MenuBarManager: ObservableObject {
     private var previousSpendValue: Double = 0.0
     private var animationTimer: Timer?
     
-    // Midnight detection properties
-    private var midnightTimer: Timer?
-    private var currentDate: Date = Date()
+    // Date rollover detection properties
+    private var dateCheckTimer: Timer?
+    private var lastKnownDate: Date = Calendar.current.startOfDay(for: Date())
     
     init() {
         Logger.app.info("🚀 Initializing ClaudeNein MenuBarManager")
@@ -50,7 +50,7 @@ class MenuBarManager: ObservableObject {
         
         setupMenuBar()
         setupStateSubscriptions()
-        setupMidnightTimer()
+        setupDateRolloverCheck()
         
         // Start the main asynchronous initialization
         Task {
@@ -88,7 +88,7 @@ class MenuBarManager: ObservableObject {
     deinit {
         Logger.app.info("🛑 Deinitializing MenuBarManager")
         animationTimer?.invalidate()
-        midnightTimer?.invalidate()
+        dateCheckTimer?.invalidate()
         statusItem = nil
         Logger.app.info("✅ MenuBarManager deinitialized")
     }
@@ -138,44 +138,30 @@ class MenuBarManager: ObservableObject {
             .store(in: &cancellables)
     }
     
-    private func setupMidnightTimer() {
-        Logger.app.debug("🕛 Setting up midnight timer for daily rollover")
-        scheduleNextMidnightCheck()
+    private func setupDateRolloverCheck() {
+        Logger.app.debug("🕛 Setting up periodic date rollover check")
+        
+        // Start a timer that fires every minute to check for date changes
+        dateCheckTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true) { [weak self] _ in
+            self?.checkForDateRollover()
+        }
     }
     
-    private func scheduleNextMidnightCheck() {
-        // Cancel existing timer
-        midnightTimer?.invalidate()
-        
+    @objc private func checkForDateRollover() {
         let calendar = Calendar.current
-        let now = Date()
+        let currentDateStart = calendar.startOfDay(for: Date())
         
-        // Get tomorrow's midnight
-        guard let nextMidnight = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now)) else {
-            Logger.app.error("❌ Failed to calculate next midnight for timer")
-            return
+        // Check if the day has changed since we last checked
+        if !calendar.isDate(currentDateStart, inSameDayAs: self.lastKnownDate) {
+            Logger.app.info("🌅 Date rollover detected - refreshing spend data")
+            Logger.app.debug("🕛 Date changed from \(self.lastKnownDate) to \(currentDateStart)")
+            
+            // Update the last known date
+            self.lastKnownDate = currentDateStart
+            
+            // Refresh spending summary to reflect new day boundaries
+            self.refreshSpendingSummary()
         }
-        
-        // Schedule timer to fire at next midnight
-        let timeInterval = nextMidnight.timeIntervalSince(now)
-        Logger.app.debug("🕛 Scheduling midnight timer to fire in \(String(format: "%.0f", timeInterval)) seconds")
-        
-        midnightTimer = Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: false) { [weak self] _ in
-            self?.handleMidnightRollover()
-        }
-    }
-    
-    @objc private func handleMidnightRollover() {
-        Logger.app.info("🌅 Midnight rollover detected - refreshing spend data")
-        
-        // Update current date
-        currentDate = Date()
-        
-        // Refresh spending summary to reflect new day boundaries
-        refreshSpendingSummary()
-        
-        // Schedule the next midnight check
-        scheduleNextMidnightCheck()
     }
     
     private func setupMenu() {


### PR DESCRIPTION
Replace complex midnight timer calculation with simpler periodic check:
- Use 60-second repeating timer instead of calculating next midnight
- Check if day has changed using Calendar.isDate comparison
- More reliable across different system states and timezone changes
- Simplifies timer management and reduces edge cases