### PR TITLE
ci: update build versioning to use GitHub run ID

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -28,7 +28,8 @@ jobs:
             CODE_SIGN_IDENTITY="" \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
-            MARKETING_VERSION="$VERSION"
+            MARKETING_VERSION="$VERSION" \
+            CURRENT_PROJECT_VERSION="${{ github.run_id }}"
       - name: Package app
         run: |
           mkdir -p dist

--- a/ClaudeNein/AboutView.swift
+++ b/ClaudeNein/AboutView.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+struct AboutView: View {
+    @Environment(\.presentationMode) var presentationMode
+    
+    private var appVersion: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "1.0"
+    }
+    
+    private var buildNumber: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "1"
+    }
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            // App Icon and Title
+            VStack(spacing: 12) {
+                Image(nsImage: NSApp.applicationIconImage!)
+                    .resizable()
+                    .frame(width: 64, height: 64)
+                
+                Text("ClaudeNein")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                
+                Text("Claude Code Spending Monitor")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+            }
+            
+            Divider()
+                .padding(.horizontal, 40)
+            
+            // Version Information
+            VStack(spacing: 8) {
+                Text("Version \(appVersion) (\(buildNumber))")
+                    .font(.body)
+                    .foregroundColor(.primary)
+            }
+            
+            // Copyright
+            Text("© 2025 Forketyfork")
+                .font(.body)
+                .foregroundColor(.secondary)
+            
+            // Repository Link
+            Button(action: openRepository) {
+                HStack {
+                    Image(systemName: "link")
+                    Text("View on GitHub")
+                }
+                .foregroundColor(.accentColor)
+            }
+            .buttonStyle(.borderless)
+            .onHover { hovering in
+                NSCursor.pointingHand.set()
+            }
+            
+            Spacer()
+            
+            // Close Button
+            Button("Close") {
+                presentationMode.wrappedValue.dismiss()
+            }
+            .keyboardShortcut(.cancelAction)
+        }
+        .padding(40)
+        .frame(width: 400, height: 350)
+    }
+    
+    private func openRepository() {
+        if let url = URL(string: "https://github.com/forketyfork/claude-nein") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+#if DEBUG
+struct AboutView_Previews: PreviewProvider {
+    static var previews: some View {
+        AboutView()
+    }
+}
+#endif

--- a/ClaudeNein/ClaudeNeinApp.swift
+++ b/ClaudeNein/ClaudeNeinApp.swift
@@ -25,6 +25,7 @@ class MenuBarManager: ObservableObject {
     private var statusItem: NSStatusItem?
 
     private var graphWindow: NSWindow?
+    private var aboutWindow: NSWindow?
     
     private var cancellables = Set<AnyCancellable>()
     
@@ -243,6 +244,10 @@ class MenuBarManager: ObservableObject {
         
         menu.addItem(NSMenuItem.separator())
         
+        let aboutItem = NSMenuItem(title: "About ClaudeNein", action: #selector(showAbout), keyEquivalent: "")
+        aboutItem.target = self
+        menu.addItem(aboutItem)
+        
         let quitItem = NSMenuItem(title: "Quit ClaudeNein", action: #selector(quitApp), keyEquivalent: "q")
         quitItem.target = self
         menu.addItem(quitItem)
@@ -325,6 +330,20 @@ class MenuBarManager: ObservableObject {
             graphWindow?.setContentSize(NSSize(width: 400, height: 300))
         }
         graphWindow?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @objc private func showAbout() {
+        if aboutWindow == nil {
+            let view = AboutView()
+            let hosting = NSHostingController(rootView: view)
+            aboutWindow = NSWindow(contentViewController: hosting)
+            aboutWindow?.title = "About ClaudeNein"
+            aboutWindow?.styleMask = [.titled, .closable]
+            aboutWindow?.setContentSize(NSSize(width: 400, height: 350))
+            aboutWindow?.center()
+        }
+        aboutWindow?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
 


### PR DESCRIPTION
- Set CURRENT_PROJECT_VERSION to GitHub run ID for unique build numbers
- Keep MARKETING_VERSION as tag-based version number
- Add About window functionality to display version info

This ensures each CI build has a unique build number while maintaining semantic versioning for releases.